### PR TITLE
Fixed errors caused by empty settings record

### DIFF
--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -27,13 +27,17 @@
                 const settingsStore = useSettingsStore()
 
                 // Fetch user settings data
-                const userSettings: { data: UserSettingsObject | undefined, success: boolean } = await $fetch('/api/settings', {
+                const userSettings: {
+                    data: UserSettingsObject | undefined
+                    success: boolean
+                } = await $fetch('/api/settings', {
                     method: 'GET',
                     headers: buildRequestHeaders(token.value)
                 })
 
                 // Load user settings
-                if(userSettings.data) settingsStore.loadCurrency(userSettings.data)
+                if (userSettings.data)
+                    settingsStore.loadCurrency(userSettings.data)
                 //-------------------------
             })
             .catch((e: NuxtError) => {

--- a/pages/login/index.vue
+++ b/pages/login/index.vue
@@ -2,6 +2,7 @@
     import { z } from 'zod'
     import type { FormSubmitEvent } from '#ui/types'
     import type { NuxtError } from '#app'
+    import type { UserSettingsObject } from '~/types/Data'
 
     const { signIn, token } = useAuth()
     const { t: $t } = useI18n()
@@ -26,14 +27,13 @@
                 const settingsStore = useSettingsStore()
 
                 // Fetch user settings data
-                const userSettings = await $fetch('/api/settings', {
+                const userSettings: { data: UserSettingsObject | undefined, success: boolean } = await $fetch('/api/settings', {
                     method: 'GET',
                     headers: buildRequestHeaders(token.value)
                 })
 
-                settingsStore.currency.id = userSettings.data.currency
-                settingsStore.currency.placement = userSettings.data.placement
-                settingsStore.currency.symbol = userSettings.data.symbol
+                // Load user settings
+                if(userSettings.data) settingsStore.loadCurrency(userSettings.data)
                 //-------------------------
             })
             .catch((e: NuxtError) => {

--- a/pages/settings/global/index.vue
+++ b/pages/settings/global/index.vue
@@ -63,7 +63,7 @@
     // Fetch user settings
     const { data: userSettings } = await useLazyAsyncData<{
         success: boolean
-        data: UserSettingsObject
+        data: UserSettingsObject | undefined
     }>('settings', () =>
         $fetch('/api/settings', {
             method: 'GET',
@@ -72,7 +72,7 @@
     )
 
     const state = reactive({
-        currency: userSettings.value?.data.currency
+        currency: userSettings.value?.data?.currency
     })
 
     const onSave = function (event: FormSubmitEvent<typeof state>) {
@@ -101,7 +101,7 @@
     }
 
     watch(userSettings, () => {
-        state.currency = userSettings.value?.data.currency
+        state.currency = userSettings.value?.data?.currency
         currencySelectKey.value++
     })
 

--- a/server/api/settings/index.get.ts
+++ b/server/api/settings/index.get.ts
@@ -14,14 +14,8 @@ export default defineEventHandler(async (event) => {
         .where('user', '=', user.id)
         .executeTakeFirst()
 
-    if (!query)
-        throw createError({
-            statusCode: 500,
-            statusMessage: 'Could not load user settings.'
-        })
-
     return {
         success: true,
-        data: query as UserSettingsObject
+        data: query as UserSettingsObject | undefined
     }
 })

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -11,8 +11,8 @@ export const useSettingsStore = defineStore('settingsStore', {
     }),
     actions: {
         loadCurrency(settings: UserSettingsObject) {
-            if(settings.symbol) this.currency.symbol = settings.symbol
-            this.currency.placement = settings.placement 
+            if (settings.symbol) this.currency.symbol = settings.symbol
+            this.currency.placement = settings.placement
         }
     },
     persist: true

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -1,13 +1,19 @@
 import type { Selectable } from 'kysely'
 import type { Currency } from 'kysely-codegen'
+import type { UserSettingsObject } from '~/types/Data'
 
 export const useSettingsStore = defineStore('settingsStore', {
     state: () => ({
         currency: {
-            id: -1,
             symbol: '€',
             placement: 'after'
         } as Selectable<Currency>
     }),
+    actions: {
+        loadCurrency(settings: UserSettingsObject) {
+            if(settings.symbol) this.currency.symbol = settings.symbol
+            this.currency.placement = settings.placement 
+        }
+    },
     persist: true
 })


### PR DESCRIPTION
When no user settings were set (this would happen on new installs), the backend would throw errors saying no valid user config was found. This has been fixed, and vue store data import has been improved with better code